### PR TITLE
using relative path for templates

### DIFF
--- a/widget-creator-war/src/main/webapp/js/override.js
+++ b/widget-creator-war/src/main/webapp/js/override.js
@@ -11,7 +11,7 @@ define(['angular'], function(angular) {
             'fname': 'widget-creator',
           },
           'SERVICE_LOC': {
-            'templates': '/json/starter-templates',
+            'templates': 'json/starter-templates',
             'widgetApi': {
               // For local testing, change to 'staticFeeds/'
               'entry': 'data:application/json;base64,',


### PR DESCRIPTION
we have a context path on the test tier, we need the url relative to that.