### PR TITLE
Add basic widget type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # widget-creator
 Web-based tool supporting developing widgets for uPortal-home.  Documentation available at https://uw-madison-doit.github.io/widget-creator/
+
+## How to run locally
+```bash
+mvn jetty:run
+```

--- a/src/main/webapp/json/starter-templates.json
+++ b/src/main/webapp/json/starter-templates.json
@@ -4,6 +4,23 @@
       "entry": {
         "layoutObject": {
           "id": 4,
+          "type": "basic",
+          "widgetType": "basic",
+          "title": "Basic Widget",
+          "hasWidgetURL": false,
+          "description": "This default widget is super easy to set up!",
+          "mdIcon": "widgets",
+          "widgetConfig": {
+            "launchText": "Launch app"
+          },
+          "url": "www.example.com"
+        }
+      }
+    },
+    {
+      "entry": {
+        "layoutObject": {
+          "id": 4,
           "type": "widget-creator",
           "widgetType": "custom",
           "title": "Custom",
@@ -29,7 +46,7 @@
             "actionURL": "https://rprg.wisc.edu/search/",
             "actionTarget": "_blank",
             "actionParameter": "q",
-            "launchText": "Go to resource guide",
+            "launchText": "Launch app",
             "links": [
               {
                 "title": "Get started",
@@ -62,7 +79,7 @@
           "jsonSample": false,
           "hasWidgetURL": false,
           "widgetConfig": {
-            "launchText": "Launch the Full App",
+            "launchText": "See all",
             "additionalText": "Additional Text",
             "links": [
               {

--- a/src/main/webapp/my-app/my-app.css
+++ b/src/main/webapp/my-app/my-app.css
@@ -1,3 +1,7 @@
+.widget-creator .bold {
+  font-weight: 600;
+}
+
 .widget-creator .portlet-body {
 	padding: 10px;
 }
@@ -19,6 +23,21 @@
 .widget-creator textarea {
 	padding: 10px 14px;
 	overflow-y: scroll;
+}
+
+.widget-creator .hint {
+  position: absolute;
+  left: 2px;
+  right: auto;
+  bottom: 7px;
+  font-size: 12px;
+  line-height: 14px;
+  transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+  color: grey;
+}
+
+.widget-creator md-input-container.has-hint {
+  margin-bottom: 32px;
 }
 
 .widget-creator ::-webkit-input-placeholder {

--- a/src/main/webapp/my-app/view-home/controllers.js
+++ b/src/main/webapp/my-app/view-home/controllers.js
@@ -15,6 +15,7 @@ define(['angular'], function(angular) {
       {'value': 'list-of-links', 'name': 'List of links'},
       {'value': 'rss', 'name': 'RSS widget'},
       {'value': 'widget-creator', 'name': 'Custom'},
+      {'value': 'basic', 'name': 'Basic'}
     ];
     $scope.selectedTemplate = {};
     $scope.preview = undefined;
@@ -45,6 +46,7 @@ define(['angular'], function(angular) {
           $scope.widget = $scope.widgetAsEditable(value.entry.layoutObject);
         }
       });
+      $scope.reload();
     };
 
     /* --------------- */

--- a/src/main/webapp/my-app/view-home/view-home.html
+++ b/src/main/webapp/my-app/view-home/view-home.html
@@ -11,7 +11,7 @@
             <p>Read
               <a href="http://uw-madison-doit.github.io/angularjs-portal/widgets.html"
                  target="_blank"
-                 rel="noopener noreferrer">the documentation on widgets</a>.
+                 rel="noopener noreferrer">widget documentation</a>.
             </p>
           </md-card-title-text>
         </md-card-title>
@@ -36,24 +36,32 @@
               <label for="desc">Description</label>
               <input type="input" id="desc" placeholder="Enter description" ng-model="widget.description">
             </md-input-container>
+            <!-- APP ICON (basic only) -->
+            <md-input-container class="md-block md-accent has-hint" ng-if="widget.type === 'basic'">
+              <label for="widget-icon">Material Icon</label>
+              <input type="input" id="widget-icon" placeholder="Provide a Material icon name" ng-model="widget.mdIcon">
+              <div class="hint">See available icons <a href="https://material.io/icons/" target="_blank" rel="nofollow">here</a>.</div>
+            </md-input-container>
             <!-- HTML TEMPLATE (custom only) -->
             <md-input-container class="md-block md-accent" ng-if="widget.type === 'widget-creator'">
-              <label for="template">HTML template *</label>
+              <label for="template">HTML template</label>
               <textarea ng-model="widget.widgetTemplate" id="template" rows="5" md-select-on-focus></textarea>
             </md-input-container>
             <!-- JSON SAMPLE (custom only) -->
-            <md-input-container class="md-block md-accent" ng-if="widget.jsonSample">
-              <label for="content">Widget URL JSON sample * **<span style="color : red;">{{ errorJSON }}</span></label>
+            <md-input-container class="md-block md-accent has-hint" ng-if="widget.jsonSample">
+              <label for="content">Widget URL JSON sample<span style="color : red;">{{ errorJSON }}</span></label>
               <textarea ng-model="widget.sample" id="content" rows="5" md-select-on-focus></textarea>
+              <div class="hint">This is usually returned by the <code>widgetURL</code>. The results are stored in the <code>$scope.content</code> variable.</div>
             </md-input-container>
             <!-- WIDGET CONFIGURATION -->
-            <md-input-container class="md-block md-accent">
-              <label for="config">Widget configuration * ***<span style="color : red;">{{ errorConfigJSON }}</span></label>
+            <md-input-container class="md-block md-accent has-hint">
+              <label for="config">Widget configuration<span style="color : red;">{{ errorConfigJSON }}</span></label>
               <textarea ng-model="widget.widgetConfig" id='config' rows="5" md-select-on-focus></textarea>
+              <div class="hint">Valid JSON provided by the widget's <code>widgetConfig</code>.</div>
             </md-input-container>
             <!-- WIDGET URL -->
             <md-input-container class="md-block md-accent" ng-if="widget.hasWidgetURL">
-              <label for="widgetURL">Widget URL *</label>
+              <label for="widgetURL">Widget URL</label>
               <input type='URL' ng-model="widget.widgetURL" id="widgetURL"></input>
             </md-input-container>
             <!-- Launch URL -->
@@ -69,10 +77,7 @@
           </div>
           <!-- NOTES -->
           <div class="help-notes" layout="column" layout-padding>
-            <p>* Changes to these fields requires you to click the refresh button to see the changes in the preview</p>
-            <p>** This is normally result from the widgetURL. This result is dumped into the "$scope.content"
-              variable.</p>
-            <p>*** Valid JSON that gets stored in '$scope.widget.widgetConfig'</p>
+            <p><span class="bold">HINT:</span> Most fields require you to click <a href="#" ng-click="reload()">Update</a> before changes appear.</p>
           </div>
         </md-card-content>
       </md-card>


### PR DESCRIPTION
**In this PR**:
- Add the basic widget type to widget creator
- Set "basic" widget as the default type
- Replace footnotes with inline "hints" 

### Screenshots
![screen shot 2017-07-17 at 12 01 42 pm](https://user-images.githubusercontent.com/5818702/28280188-8e05e072-6ae8-11e7-8fb7-4d3854a98be4.png)

Example of inline hint:

![screen shot 2017-07-17 at 12 07 26 pm](https://user-images.githubusercontent.com/5818702/28280190-8e08012c-6ae8-11e7-98f7-0f58a043181f.png)

Remaining footnote:

![screen shot 2017-07-17 at 12 07 35 pm](https://user-images.githubusercontent.com/5818702/28280189-8e06ca28-6ae8-11e7-9c53-829b97cc75cf.png)
