### PR TITLE
Fix Session url to be staticFeed

### DIFF
--- a/src/main/webapp/js/override.js
+++ b/src/main/webapp/js/override.js
@@ -16,7 +16,7 @@ define(['angular'], function(angular) {
         'kvURL': null,
         'groupURL': 'staticFeeds/groups.json',
         'sessionInfo': 'staticFeeds/guest-session.json',
-        'shibbolethSessionURL': '/Shibboleth.sso/Session.json',
+        'shibbolethSessionURL': 'staticFeeds/Shibboleth.sso/Session.json',
         'templates': 'json/starter-templates',
         'widgetApi': {
           // For local testing, change to 'staticFeeds/'


### PR DESCRIPTION
Somehow I forgot this in the pull request that was supposed to address this