### PR TITLE
Upgrade framework version and default to material icons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.apereo.uportal</groupId>
       <artifactId>uportal-app-framework</artifactId>
-      <version>7.0.1-SNAPSHOT</version>
+      <version>9.2.0</version>
       <type>war</type>
     </dependency>
   </dependencies>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,7 @@
       <url-pattern>/settings</url-pattern>
       <url-pattern>/user-settings</url-pattern>
       <url-pattern>/about</url-pattern>
+      <url-pattern>/version-info</url-pattern>
       <url-pattern>/access-denied</url-pattern>
   </servlet-mapping>
 </web-app>

--- a/src/main/webapp/js/override.js
+++ b/src/main/webapp/js/override.js
@@ -16,7 +16,6 @@ define(['angular'], function(angular) {
     },
     SERVICE_LOC: {
       kvURL: null,
-      aboutPageURL: 'json/about-widget-creator.json',
       groupURL: 'staticFeeds/groups.json',
       sessionInfo: 'staticFeeds/guest-session.json',
       shibbolethSessionURL: 'staticFeeds/Shibboleth.sso/Session.json',

--- a/src/main/webapp/js/override.js
+++ b/src/main/webapp/js/override.js
@@ -7,12 +7,16 @@ define(['angular'], function(angular) {
       isWeb: false,
       loginOnLoad: false,
     },
+    APP_OPTIONS: {
+      appMenuTemplateURL: '/my-app/navigation/drawer.html',
+    },
     NAMES: {
       title: 'Widget Creator',
       fname: 'widget-creator',
     },
     SERVICE_LOC: {
       kvURL: null,
+      aboutPageURL: 'json/about-widget-creator.json',
       groupURL: 'staticFeeds/groups.json',
       sessionInfo: 'staticFeeds/guest-session.json',
       shibbolethSessionURL: 'staticFeeds/Shibboleth.sso/Session.json',

--- a/src/main/webapp/json/about-widget-creator.json
+++ b/src/main/webapp/json/about-widget-creator.json
@@ -1,0 +1,22 @@
+{
+  "description": "Widget creator",
+  "keywords": "widget, widgets, myuw, madison, wisconsin",
+  "aboutText": [
+    "This tool supports the development of widgets for MyUW (or other apps in the MyUW ecosystem). Here developers and product owners can experiment with the different types of widgets or create custom widgets from scratch.",
+    "Because Widget Creator is built on the same framework as MyUW, you can be confident that the live preview of widgets created here will reflect exactly how they will look/perform in MyUW proper."
+  ],
+  "aboutLinks": [
+    {
+      "url": "https://docs.google.com/a/wisc.edu/forms/d/1h4t8IVveOK-kYQPuZceW9z4ZZiYepUnWD-BE4A58mnE/viewform",
+      "text": "Suggest an item for the MyUW app directory"
+    },
+    {
+      "url": "https://github.com/UW-Madison-DoIT/widget-creator",
+      "text": "Widget creator on GitHub"
+    },
+    {
+      "url": "https://tools.my.wisc.edu/home/",
+      "text": "Other tools created by the MyUW team"
+    }
+  ]
+}

--- a/src/main/webapp/json/starter-templates.json
+++ b/src/main/webapp/json/starter-templates.json
@@ -51,14 +51,14 @@
               {
                 "title": "Get started",
                 "href": "https://rprg.wisc.edu/phases/initiate/",
-                "icon": "fa-map-o",
+                "icon": "directions",
                 "target": "_blank",
                 "rel": "noopener noreferrer"
               },
               {
                 "title": "Resources",
                 "href": "https://rprg.wisc.edu/category/resource/",
-                "icon": "fa-th-list",
+                "icon": "folder_open",
                 "target": "_blank",
                 "rel": "noopener noreferrer"
               }
@@ -85,14 +85,14 @@
               {
                 "title": "The Google",
                 "href": "http://www.google.com",
-                "icon": "fa-google",
+                "icon": "mood",
                 "target": "_blank",
                 "rel": "noopener noreferrer"
               },
               {
                 "title": "Bing",
                 "href": "http://www.bing.com",
-                "icon": "fa-bed",
+                "icon": "mood_bad",
                 "target": "_blank",
                 "rel": "noopener noreferrer"
               }

--- a/src/main/webapp/my-app/main.js
+++ b/src/main/webapp/my-app/main.js
@@ -4,7 +4,7 @@ define(
     'require',
     './view-home/routes', // add all the paths to your routes here
     'portal/settings/routes', // example pulling in portal module routes
-    'portal/about/route', // Nice about page for your application
+    'portal/about/routes', // Nice about page for your application
     'portal/main/routes',
     'portal',
     'app-config',
@@ -20,7 +20,7 @@ define(
     require,
     homeRoutes,
     settingsRoutes,
-    aboutRoute,
+    aboutRoutes,
     mainRoutes
   ) {
     // notice each route file is now an object
@@ -45,7 +45,8 @@ define(
             .when('/home', homeRoutes.home)
             .when('/settings', settingsRoutes.betaSettings)
             .when('/user-settings', settingsRoutes.userSettings)
-            .when('/about', aboutRoute)
+            .when('/about', aboutRoutes.about)
+            .when('/version-info', aboutRoutes.sessionInfo)
             .when('/access-denied', mainRoutes.accessDenied)
             .otherwise({redirectTo: '/home'});
         },

--- a/src/main/webapp/my-app/main.js
+++ b/src/main/webapp/my-app/main.js
@@ -45,7 +45,6 @@ define(
             .when('/home', homeRoutes.home)
             .when('/settings', settingsRoutes.betaSettings)
             .when('/user-settings', settingsRoutes.userSettings)
-            .when('/about', aboutRoutes.about)
             .when('/version-info', aboutRoutes.sessionInfo)
             .when('/access-denied', mainRoutes.accessDenied)
             .otherwise({redirectTo: '/home'});

--- a/src/main/webapp/my-app/my-app.css
+++ b/src/main/webapp/my-app/my-app.css
@@ -1,3 +1,15 @@
+.wrapper__page-title > h1.md-display-1 {
+  display: none;
+}
+
+.view__home {
+  padding: 0 12px 24px;
+}
+
+.view__home .widget-preview {
+  margin: 0 24px;
+}
+
 .widget-creator .bold {
   font-weight: 600;
 }

--- a/src/main/webapp/my-app/navigation/drawer.html
+++ b/src/main/webapp/my-app/navigation/drawer.html
@@ -1,0 +1,40 @@
+<md-menu-item>
+  <md-button href="/" ng-click="vm.closeMainMenu();" layout="row" layout-align="start center">
+    <span>
+      <md-icon>home</md-icon>
+    </span>
+    <span>Widget creator home</span>
+  </md-button>
+</md-menu-item>
+<md-menu-item>
+  <md-button href="/about" ng-click="vm.closeMainMenu();" layout="row" layout-align="start center">
+    <span>
+      <md-icon>details</md-icon>
+    </span>
+    <span>About</span>
+  </md-button>
+</md-menu-item>
+<md-menu-item>
+  <md-button href="/version-info" ng-click="vm.closeMainMenu();" layout="row" layout-align="start center">
+    <span>
+      <md-icon>info</md-icon>
+    </span>
+    <span>Version info</span>
+  </md-button>
+</md-menu-item>
+<md-menu-item>
+  <md-button href="https://tools.my.wisc.edu/home/" ng-click="vm.closeMainMenu();" layout="row" layout-align="start center">
+    <span>
+      <md-icon>widgets</md-icon>
+    </span>
+    <span>Other tools</span>
+  </md-button>
+</md-menu-item>
+<md-menu-item>
+  <md-button href="https://uw-madison-doit.github.io/widget-creator/" ng-click="vm.closeMainMenu();" layout="row" layout-align="start center">
+    <span>
+      <md-icon>book</md-icon>
+    </span>
+    <span>Documentation</span>
+  </md-button>
+</md-menu-item>

--- a/src/main/webapp/my-app/view-home/controllers.js
+++ b/src/main/webapp/my-app/view-home/controllers.js
@@ -140,7 +140,6 @@ define(['angular'], function(angular) {
               .getStarterTemplates()
               .then(function(templates) {
                 starterTemplates = templates;
-                $log.log('Got starter templates');
                 if (templates[0].entry.layoutObject) {
                   // Set default widget type
                   $scope.widget = $scope.widgetAsEditable(

--- a/src/main/webapp/my-app/view-home/view-home.html
+++ b/src/main/webapp/my-app/view-home/view-home.html
@@ -1,12 +1,11 @@
 <frame-page class="widget-creator"
             app-title="Widget Creator"
-            app-icon="widgets"
+            page-title="Widget Creator"
             app-fname="widget-creator"
-            app-has-page-level-sidenav="false"
             white-background="false">
-  <div class="portlet-body" layout-gt-sm="row" layout-sm="column" ng-controller="WidgetCreatorController as widgetCreatorCtrl">
+  <div class="view__home" layout-gt-sm="row" layout-sm="column" ng-controller="WidgetCreatorController as widgetCreatorCtrl">
     <!-- WIDGET CONFIGURATION FORM -->
-    <md-card flex-gt-sm="60" class="config" layout-padding>
+    <md-card flex class="config" layout-padding>
       <md-card-title>
         <md-card-title-text>
           <span class="md-title">Smart Widget Configuration</span>
@@ -84,7 +83,7 @@
       </md-card-content>
     </md-card>
     <!-- WIDGET PREVIEW -->
-    <div flex-gt-sm="40">
+    <div class="widget-preview">
       <div class="list-container no-padding output" layout="row" layout-align="center center">
         <preview-widget ng-attr-fname="{{ preview }}"></preview-widget>
       </div>


### PR DESCRIPTION
[MUMMNG-4176](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4176): "As a partner using Widget Creator to create widgets, I would like the widget creator to default using material icons, so that I know how to use the recommended solution."

**In this PR**:
- Starter templates for widget types use material icons
- Upgrade to uportal-app-framework version 9.2.0


### Screenshots
![screen shot 2018-05-30 at 10 05 06 am](https://user-images.githubusercontent.com/5818702/40734095-11c3196c-63fd-11e8-98a2-10893d0aa725.png)
![screen shot 2018-05-30 at 11 29 28 am](https://user-images.githubusercontent.com/5818702/40734096-11d33a7c-63fd-11e8-8b83-a5e7bcc9b14c.png)
