### PR TITLE
fix(list-of-links): rm "rel" in list-of-links widgetConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed in next release
 
++ Stopped suggesting doesn't-actually-do-anything `rel` in `list-of-links`
+  `widgetConfig`. ( [#35][], [MUMMNG-4380][] )
 + Upgraded dependencies, including to resolve vulnerabilities ( [#34][] )
 
 ## 1.0.2
@@ -45,6 +47,8 @@ Initial v1 release.
 [#32]: https://github.com/UW-Madison-DoIT/widget-creator/pull/32
 [#33]: https://github.com/UW-Madison-DoIT/widget-creator/pull/33
 [#34]: https://github.com/UW-Madison-DoIT/widget-creator/pull/34
+[#35]: https://github.com/UW-Madison-DoIT/widget-creator/pull/35
 [MUMMNG-4176]: https://jira.doit.wisc.edu/jira/browse/MUMMNG-4176
+[MUMMNG-4380]:  https://jira.doit.wisc.edu/jira/browse/MUMMNG-4380
 [MUMUP-3138]: https://jira.doit.wisc.edu/jira/browse/MUMUP-3138
 [uPortal-app-framework 9.2.0]: https://github.com/uPortal-Project/uportal-app-framework/blob/master/CHANGELOG.md#920---2018-05-22

--- a/docs/listOfLinksWidgetExercise.md
+++ b/docs/listOfLinksWidgetExercise.md
@@ -12,7 +12,7 @@ A title and description have already been provided.
 
 Widget configuration - Notice that sample text has already been provided:
 ```json
-{"launchText":"Launch the Full App","additionalText":"Additional Text","links":[{"title":"The Google","href":"http://www.google.com","icon":"fa-google","target":"_blank","rel":"noopener noreferrer"},{"title":"Bing","href":"http://www.bing.com","icon":"fa-bed","target":"_blank","rel":"noopener noreferrer"}]}
+{"launchText":"Launch the Full App","additionalText":"Additional Text","links":[{"title":"The Google","href":"http://www.google.com","icon":"fa-google","target":"_blank"},{"title":"Bing","href":"http://www.bing.com","icon":"fa-bed","target":"_blank"}]}
 ```
 
 Let’s format that JSON so it’s easier to read
@@ -25,15 +25,13 @@ Let’s format that JSON so it’s easier to read
       "title": "The Google",
       "href": "http://www.google.com",
       "icon": "fa-google",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     },
     {
       "title": "Bing",
       "href": "http://www.bing.com",
       "icon": "fa-bed",
-      "target": "_blank",
-      "rel": "noopener noreferrer"
+      "target": "_blank"
     }
   ]
 }
@@ -58,8 +56,7 @@ For the widget config, copy and paste this:
       "title":"uPortal",
       "href":"https://www.apereo.org/projects/uportal",
       "icon":"fa-google",
-      "target":"_blank",
-      "rel":"noopener  noreferrer"
+      "target":"_blank"
     }
   ]
 }
@@ -85,15 +82,13 @@ Try adding more links.  If you need help, here’s some sample widget configurat
       "title": "uPortal",
       "href": "https://www.apereo.org/projects/uportal",
       "icon": "fa-key",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     },
     {
       "title": "Sakai Project",
       "href": "https://www.apereo.org/projects/sakai-project",
       "icon": "fa-folder-open",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     }
   ]
 }
@@ -112,22 +107,19 @@ Try three links
       "title": "uPortal",
       "href": "https://www.apereo.org/projects/uportal",
       "icon": "fa-key",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     },
     {
       "title": "Sakai Project",
       "href": "https://www.apereo.org/projects/sakai-project",
       "icon": "fa-folder-open",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     },
     {
       "title": "Student Success Plan",
       "href": "https://www.apereo.org/projects/student-success-plan",
       "icon": "fa-graduation-cap",
-      "target": "_blank",
-      "rel": "noopener  noreferrer"
+      "target": "_blank"
     }
   ]
 }

--- a/src/main/webapp/json/starter-templates.json
+++ b/src/main/webapp/json/starter-templates.json
@@ -86,15 +86,13 @@
                 "title": "The Google",
                 "href": "http://www.google.com",
                 "icon": "mood",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
+                "target": "_blank"
               },
               {
                 "title": "Bing",
                 "href": "http://www.bing.com",
                 "icon": "mood_bad",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
+                "target": "_blank"
               }
             ]
           },


### PR DESCRIPTION
`links[{rel=}]` [is not a thing](https://github.com/uPortal-Project/uportal-app-framework/pull/814), so remove documentation and template suggesting it is a thing, so it doesn't make its way from widget-creator-generated JSON [into widgetConfig in actual entity files](https://git.doit.wisc.edu/myuw-overlay/entities/merge_requests/1576#note_111335).

Before:

<img width="1358" alt="widget-creator-generates-rel" src="https://user-images.githubusercontent.com/952283/46827535-6df20e80-cd5e-11e8-9c90-d087ac6cebd5.png">

After:

<img width="1059" alt="widget-creator-no-longer-generates-rel" src="https://user-images.githubusercontent.com/952283/46827525-66326a00-cd5e-11e8-8024-36fe5bbdb436.png">

